### PR TITLE
Add functionality to save and load settings to/from files

### DIFF
--- a/skyegpt-backend/.dockerignore
+++ b/skyegpt-backend/.dockerignore
@@ -6,6 +6,7 @@ skyeGpt.iml
 content/
 .idea/
 .DS_Store
+settings/
 
 # Ignore version control systems
 .git

--- a/skyegpt-backend/.gitignore
+++ b/skyegpt-backend/.gitignore
@@ -11,6 +11,7 @@ skyegpt-backend/Tests/chroma/
 content/
 .idea/
 .DS_Store
+settings/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/skyegpt-backend/Utils.py
+++ b/skyegpt-backend/Utils.py
@@ -1,5 +1,7 @@
 import markdown
 from typing import Generator
+import os
+import json
 
 
 def convert_md_to_html(
@@ -15,3 +17,25 @@ def format_to_sse(
     for chunk in chunks:
         chunk = chunk.replace("\n", "\\n")
         yield f"data: {chunk}\n\n"
+
+
+def save_settings_to_file(
+        my_dict: dict,
+        json_name: str
+):
+    folder_path = "settings"
+    os.makedirs(folder_path, exist_ok=True)
+    file_path = os.path.join(folder_path, json_name)
+
+    with open(file_path, "w") as json_file:
+        json.dump(my_dict, json_file, indent=4)
+
+
+def load_settings_from_file(
+        file_name: str
+):
+    folder_path = "settings"
+    file_path = os.path.join(folder_path, file_name)
+    with open(file_path, "r") as f:
+        loaded_dict = json.load(f)
+    return loaded_dict


### PR DESCRIPTION
Introduced utility methods `save_settings_to_file` and `load_settings_from_file` to manage application settings. Integrated these methods into the `main.py` lifecycle to load settings on startup and save them on shutdown. Updated `.gitignore` and `.dockerignore` to exclude the new `settings` directory.