### PR TITLE
Removing the hard-coded 9.0, and 8.0 version numbers from the version-selector

### DIFF
--- a/skyegpt-frontend/src/app/page.tsx
+++ b/skyegpt-frontend/src/app/page.tsx
@@ -27,7 +27,7 @@ const HomePage = () => {
   }, []);
 
   // PLACEHOLDER
-  const versions = ['10.0', '9.0', '8.0'];
+  const versions = ['10.0'];
 
   return (
     <div className="w-screen min-h-screen max-w-full flex flex-col overflow-hidden bg-gray-50">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c0f69c94-2018-4ce6-a700-d3dee9c97edb)
